### PR TITLE
fix keycloak realm export

### DIFF
--- a/services/keycloak/import/realm-export.json
+++ b/services/keycloak/import/realm-export.json
@@ -745,7 +745,7 @@
     } ],
     "disableableCredentialTypes" : [ ],
     "requiredActions" : [ ],
-    "realmRoles" : [ "bmiaip_editor", "default-roles-aip-dev" ],
+    "realmRoles" : [ "default-roles-aip-dev" ],
     "notBefore" : 0,
     "groups" : [ "/bmiaip_owner" ]
   }, {


### PR DESCRIPTION
Currently we tried moving to the new keycloak. The tests are failing because of a wrong realmRole with a certain test user that we use for the e2e testing.  

@Kbroeren could you please have a look at this PR.